### PR TITLE
Ensure AppVeyor discovers all test assemblies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,11 @@ before_build:
 - cmd: nuget restore
 build:
   verbosity: minimal
+configuration:
+  - Release
 test:
   assemblies:
     only:
-      - toofz.NecroDancer.Tests\bin\Debug\toofz.NecroDancer.Tests.dll
-      - toofz.NecroDancer.Leaderboards.Tests\bin\Debug\toofz.NecroDancer.Leaderboards.Tests.dll
-      - toofz.NecroDancer.Web.Api.Tests\bin\Debug\toofz.NecroDancer.Web.Api.Tests.dll
+      - toofz.NecroDancer.Tests\bin\$(CONFIGURATION)\toofz.NecroDancer.Tests.dll
+      - toofz.NecroDancer.Leaderboards.Tests\bin\$(CONFIGURATION)\toofz.NecroDancer.Leaderboards.Tests.dll
+      - toofz.NecroDancer.Web.Api.Tests\bin\$(CONFIGURATION)\toofz.NecroDancer.Web.Api.Tests.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,6 @@ build:
 test:
   assemblies:
     only:
-      - toofz.NecroDancer.Tests\bin\$(configuration)\toofz.NecroDancer.Tests.dll
-      - toofz.NecroDancer.Leaderboards.Tests\bin\$(configuration)\toofz.NecroDancer.Leaderboards.Tests.dll
-      - toofz.NecroDancer.Web.Api.Tests\bin\$(configuration)\toofz.NecroDancer.Web.Api.Tests.dll
+      - toofz.NecroDancer.Tests\bin\Debug\toofz.NecroDancer.Tests.dll
+      - toofz.NecroDancer.Leaderboards.Tests\bin\Debug\toofz.NecroDancer.Leaderboards.Tests.dll
+      - toofz.NecroDancer.Web.Api.Tests\bin\Debug\toofz.NecroDancer.Web.Api.Tests.dll


### PR DESCRIPTION
AppVeyor's auto-detection only discovers `toofz.NecroDancer.Web.Api.Tests`. To fix this, `appveyor.yml` is added to manually declare test assemblies.