### PR TITLE
Refactor leaderboards pipeline

### DIFF
--- a/toofz.NecroDancer.Leaderboards.Services.LeaderboardUpdate/WorkerRole.cs
+++ b/toofz.NecroDancer.Leaderboards.Services.LeaderboardUpdate/WorkerRole.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using toofz.NecroDancer.Leaderboards.EntityFramework;
 using toofz.NecroDancer.Leaderboards.Services.Common;
 using toofz.NecroDancer.Leaderboards.Steam.ClientApi;
 
@@ -13,9 +14,16 @@ namespace toofz.NecroDancer.Leaderboards.Services.LeaderboardUpdate
 
         protected override async Task RunAsyncOverride(CancellationToken cancellationToken)
         {
-            var steamClient = new SteamClientApiClient();
+            var userName = Util.GetEnvVar("SteamUserName");
+            var password = Util.GetEnvVar("SteamPassword");
+            var steamClient = new SteamClientApiClient(userName, password);
             await LeaderboardsClient.UpdateLeaderboardsAsync(steamClient, cancellationToken).ConfigureAwait(false);
-            await LeaderboardsClient.UpdateDailyLeaderboardsAsync(steamClient, cancellationToken).ConfigureAwait(false);
+
+            var leaderboardsConnectionString = Util.GetEnvVar("LeaderboardsConnectionString");
+            using (var db = new LeaderboardsContext(leaderboardsConnectionString))
+            {
+                await LeaderboardsClient.UpdateDailyLeaderboardsAsync(steamClient, db, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/toofz.NecroDancer.Leaderboards.Services.LeaderboardUpdate/packages.config
+++ b/toofz.NecroDancer.Leaderboards.Services.LeaderboardUpdate/packages.config
@@ -10,4 +10,5 @@
   <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="toofz" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/toofz.NecroDancer.Leaderboards.Services.LeaderboardUpdate/toofz.NecroDancer.Leaderboards.Services.LeaderboardUpdate.csproj
+++ b/toofz.NecroDancer.Leaderboards.Services.LeaderboardUpdate/toofz.NecroDancer.Leaderboards.Services.LeaderboardUpdate.csproj
@@ -82,6 +82,9 @@
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceProcess" />
+    <Reference Include="toofz, Version=2.1.0.20911, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\toofz.2.1.0\lib\net45\toofz.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
@@ -101,6 +104,7 @@
     </None>
     <None Include="leaderboard-log.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
     </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/toofz.NecroDancer.Leaderboards.Tests/ApiClientTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/ApiClientTests.cs
@@ -9,7 +9,7 @@ using toofz.TestsShared;
 
 namespace toofz.NecroDancer.Leaderboards.Tests
 {
-    public class ApiClientTests
+    class ApiClientTests
     {
         static readonly CancellationToken Cancellation = CancellationToken.None;
 

--- a/toofz.NecroDancer.Leaderboards.Tests/ApiExceptionTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/ApiExceptionTests.cs
@@ -8,7 +8,7 @@ using toofz.TestsShared;
 
 namespace toofz.NecroDancer.Leaderboards.Tests
 {
-    public class ApiExceptionTests
+    class ApiExceptionTests
     {
         [TestClass]
         public class CreateAsync

--- a/toofz.NecroDancer.Leaderboards.Tests/EnsureSuccessHandlerTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/EnsureSuccessHandlerTests.cs
@@ -8,7 +8,7 @@ using toofz.TestsShared;
 
 namespace toofz.NecroDancer.Leaderboards.Tests
 {
-    public class EnsureSuccessHandlerTests
+    class EnsureSuccessHandlerTests
     {
         [TestClass]
         public class SendAsync

--- a/toofz.NecroDancer.Leaderboards.Tests/ITargetBlockExtensionsTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/ITargetBlockExtensionsTests.cs
@@ -8,7 +8,7 @@ namespace toofz.NecroDancer.Leaderboards.Tests
     class ITargetBlockExtensionsTests
     {
         [TestClass]
-        public class CheckSendAsyncTests
+        public class CheckSendAsync
         {
             [TestMethod]
             public async Task TargetIsNull_ThrowsArgumentNullException()

--- a/toofz.NecroDancer.Leaderboards.Tests/LeaderboardsClientTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/LeaderboardsClientTests.cs
@@ -1,18 +1,122 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Moq;
+using SteamKit2;
+using toofz.NecroDancer.Leaderboards.EntityFramework;
+using toofz.NecroDancer.Leaderboards.Steam.ClientApi;
 using toofz.NecroDancer.Leaderboards.Steam.WebApi;
 using toofz.TestsShared;
+using static SteamKit2.SteamUserStats.LeaderboardEntriesCallback;
 
 namespace toofz.NecroDancer.Leaderboards.Tests
 {
     class LeaderboardsClientTests
     {
+        [TestClass]
+        public class UpdateLeaderboardsAsync
+        {
+            [TestMethod]
+            public async Task ValidParams_UpdatesLeaderboards()
+            {
+                // Arrange
+                var mockSteamWebApiClient = new Mock<ISteamWebApiClient>();
+                var mockILeaderboardsSqlClient = new Mock<ILeaderboardsSqlClient>();
+                var mockApiClient = new Mock<IApiClient>();
+                var mockUgcHttpClient = new Mock<IUgcHttpClient>();
+                var leaderboardsClient = new LeaderboardsClient(
+                    mockSteamWebApiClient.Object,
+                    mockILeaderboardsSqlClient.Object,
+                    mockApiClient.Object,
+                    mockUgcHttpClient.Object);
+
+                var mockILeaderboardEntriesCallback = new Mock<ILeaderboardEntriesCallback>();
+                mockILeaderboardEntriesCallback
+                    .Setup(leaderboardEntries => leaderboardEntries.Entries)
+                    .Returns(new ReadOnlyCollection<LeaderboardEntry>(new List<LeaderboardEntry>()));
+
+                var mockISteamClientApiClient = new Mock<ISteamClientApiClient>();
+                mockISteamClientApiClient
+                    .Setup(steamClient => steamClient.GetLeaderboardEntriesAsync(It.IsAny<uint>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(mockILeaderboardEntriesCallback.Object));
+
+                // Act
+                await leaderboardsClient.UpdateLeaderboardsAsync(mockISteamClientApiClient.Object);
+
+                // Assert
+                mockILeaderboardsSqlClient.Verify(sqlClient => sqlClient.SaveChangesAsync(It.IsAny<IEnumerable<Leaderboard>>(), It.IsAny<CancellationToken>()));
+                mockILeaderboardsSqlClient.Verify(sqlClient => sqlClient.SaveChangesAsync(It.IsAny<IEnumerable<Player>>(), false, It.IsAny<CancellationToken>()));
+                mockILeaderboardsSqlClient.Verify(sqlClient => sqlClient.SaveChangesAsync(It.IsAny<IEnumerable<Replay>>(), false, It.IsAny<CancellationToken>()));
+                mockILeaderboardsSqlClient.Verify(sqlClient => sqlClient.SaveChangesAsync(It.IsAny<IEnumerable<Entry>>()));
+            }
+        }
+
+        [TestClass]
+        public class UpdateDailyLeaderboardsAsync
+        {
+            [TestMethod]
+            public async Task ValidParams_UpdatesDailyLeaderboards()
+            {
+                // Arrange
+                var mockSteamWebApiClient = new Mock<ISteamWebApiClient>();
+                var mockILeaderboardsSqlClient = new Mock<ILeaderboardsSqlClient>();
+                var mockApiClient = new Mock<IApiClient>();
+                var mockUgcHttpClient = new Mock<IUgcHttpClient>();
+                var leaderboardsClient = new LeaderboardsClient(
+                    mockSteamWebApiClient.Object,
+                    mockILeaderboardsSqlClient.Object,
+                    mockApiClient.Object,
+                    mockUgcHttpClient.Object);
+
+                var mockIFindOrCreateLeaderboardCallback = new Mock<IFindOrCreateLeaderboardCallback>();
+
+                var mockILeaderboardEntriesCallback = new Mock<ILeaderboardEntriesCallback>();
+                mockILeaderboardEntriesCallback
+                    .Setup(leaderboardEntries => leaderboardEntries.Entries)
+                    .Returns(new ReadOnlyCollection<LeaderboardEntry>(new List<LeaderboardEntry>()));
+
+                var mockISteamClientApiClient = new Mock<ISteamClientApiClient>();
+                mockISteamClientApiClient
+                    .Setup(steamClient => steamClient.FindLeaderboardAsync(It.IsAny<uint>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(mockIFindOrCreateLeaderboardCallback.Object));
+                mockISteamClientApiClient
+                    .Setup(steamClient => steamClient.GetLeaderboardEntriesAsync(It.IsAny<uint>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(mockILeaderboardEntriesCallback.Object));
+
+                var dailyLeaderboards = new List<DailyLeaderboard>
+                {
+                    new DailyLeaderboard
+                    {
+                        LeaderboardId = 2089328,
+                        Date = new DateTime(2017, 8, 6, 0, 0, 0, DateTimeKind.Utc),
+                        LastUpdate = new DateTime(2017, 8, 6, 13, 20, 32, DateTimeKind.Utc),
+                        ProductId = 1,
+                        IsProduction = true,
+                    },
+                };
+                var mockSetDailyLeaderboard = MockHelper.MockSet(dailyLeaderboards);
+
+                var mockLeaderboardsContext = new Mock<LeaderboardsContext>();
+                mockLeaderboardsContext
+                    .Setup(x => x.DailyLeaderboards)
+                    .Returns(mockSetDailyLeaderboard.Object);
+
+                // Act
+                await leaderboardsClient.UpdateDailyLeaderboardsAsync(mockISteamClientApiClient.Object, mockLeaderboardsContext.Object);
+
+                // Assert
+                mockILeaderboardsSqlClient.Verify(sqlClient => sqlClient.SaveChangesAsync(It.IsAny<IEnumerable<DailyLeaderboard>>(), It.IsAny<CancellationToken>()));
+                mockILeaderboardsSqlClient.Verify(sqlClient => sqlClient.SaveChangesAsync(It.IsAny<IEnumerable<Player>>(), false, It.IsAny<CancellationToken>()));
+                mockILeaderboardsSqlClient.Verify(sqlClient => sqlClient.SaveChangesAsync(It.IsAny<IEnumerable<Replay>>(), false, It.IsAny<CancellationToken>()));
+                mockILeaderboardsSqlClient.Verify(sqlClient => sqlClient.SaveChangesAsync(It.IsAny<IEnumerable<DailyEntry>>(), It.IsAny<CancellationToken>()));
+            }
+        }
+
         [TestClass]
         public class UpdatePlayersAsync
         {

--- a/toofz.NecroDancer.Leaderboards.Tests/Steam/ClientApi/ProgressDebugNetworkListenerTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/Steam/ClientApi/ProgressDebugNetworkListenerTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SteamKit2;
+using toofz.NecroDancer.Leaderboards.Steam.ClientApi;
+using toofz.TestsShared;
+
+namespace toofz.NecroDancer.Leaderboards.Tests.Steam.ClientApi
+{
+    class ProgressDebugNetworkListenerTests
+    {
+        [TestClass]
+        public class OnIncomingNetworkMessage
+        {
+            [TestMethod]
+            public void ProgressIsNull_DoesNotThrowNullReferenceException()
+            {
+                // Arrange
+                var listener = new ProgressDebugNetworkListener();
+
+                // Act
+                var ex = Record.Exception(() =>
+                {
+                    listener.OnIncomingNetworkMessage(EMsg.AdminCmd, new byte[0]);
+                });
+
+                // Assert
+                Assert.IsNull(ex);
+            }
+
+            [TestMethod]
+            public void ProgressIsNotNull_ReportsDataLength()
+            {
+                // Arrange
+                var data = new byte[3];
+
+                var mockProgress = new Mock<IProgress<long>>();
+                mockProgress
+                    .Setup(p => p.Report(data.Length));
+
+                var listener = new ProgressDebugNetworkListener { Progress = mockProgress.Object };
+
+                // Act
+                listener.OnIncomingNetworkMessage(EMsg.AdminCmd, data);
+
+                // Assert
+                mockProgress.VerifyAll();
+            }
+        }
+    }
+}

--- a/toofz.NecroDancer.Leaderboards.Tests/Steam/ClientApi/SteamClientApiClientTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/Steam/ClientApi/SteamClientApiClientTests.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SteamKit2;
+using toofz.NecroDancer.Leaderboards.Steam.ClientApi;
+using toofz.TestsShared;
+
+namespace toofz.NecroDancer.Leaderboards.Tests.Steam.ClientApi
+{
+    class SteamClientApiClientTests
+    {
+        [TestClass]
+        public class Constructor
+        {
+            [TestMethod]
+            public void UsernameIsNull_ThrowsArgumentNullException()
+            {
+                // Arrange
+                string userName = null;
+                string password = "password";
+
+                // Act
+                var ex = Record.Exception(() =>
+                {
+                    new SteamClientApiClient(userName, password);
+                });
+
+                // Assert
+                Assert.IsInstanceOfType(ex, typeof(ArgumentNullException));
+            }
+
+            [TestMethod]
+            public void PasswordIsNull_ThrowsArgumentNullException()
+            {
+                // Arrange
+                string userName = "userName";
+                string password = null;
+
+                // Act
+                var ex = Record.Exception(() =>
+                {
+                    new SteamClientApiClient(userName, password);
+                });
+
+                // Assert
+                Assert.IsInstanceOfType(ex, typeof(ArgumentNullException));
+            }
+
+            [TestMethod]
+            public void ValidParams_ReturnsSteamClientApiClient()
+            {
+                // Arrange
+                string userName = "userName";
+                string password = "password";
+
+                // Act
+                var client = new SteamClientApiClient(userName, password);
+
+                // Assert
+                Assert.IsInstanceOfType(client, typeof(SteamClientApiClient));
+            }
+        }
+
+        [TestClass]
+        public class FindLeaderboardAsync
+        {
+            const string UserName = "userName";
+            const string Password = "password";
+            const uint AppId = 247080;
+            const string LeaderboardName = "Leaderboard Name";
+
+            Mock<IFindOrCreateLeaderboardCallback> mockIFindOrCreateLeaderboardCallback;
+            Mock<ISteamUserStats> mockISteamUserStats;
+            Mock<ISteamClient> mockISteamClient;
+            Mock<ICallbackManager> mockICallbackManager;
+            SteamClientApiClient steamClientApiClient;
+
+            [TestInitialize]
+            public void TestInitialize()
+            {
+                mockIFindOrCreateLeaderboardCallback = new Mock<IFindOrCreateLeaderboardCallback>();
+
+                mockISteamUserStats = new Mock<ISteamUserStats>();
+                mockISteamUserStats
+                    .Setup(s => s.FindLeaderboard(It.IsAny<uint>(), It.IsAny<string>()))
+                    .Returns(Task.FromResult(mockIFindOrCreateLeaderboardCallback.Object));
+
+                mockISteamClient = new Mock<ISteamClient>();
+                mockISteamClient
+                    .Setup(c => c.GetSteamUserStats())
+                    .Returns(mockISteamUserStats.Object);
+
+                mockICallbackManager = new Mock<ICallbackManager>();
+                mockICallbackManager
+                    .SetupGet(manager => manager.SteamClient)
+                    .Returns(mockISteamClient.Object);
+
+                steamClientApiClient = new SteamClientApiClient(UserName, Password, mockICallbackManager.Object);
+            }
+
+            [TestMethod]
+            public async Task ResultIsNotOK_ThrowsSteamClientApiException()
+            {
+                // Arrange
+                mockIFindOrCreateLeaderboardCallback
+                    .Setup(le => le.Result)
+                    .Returns(EResult.Fail);
+
+                // Act
+                var ex = await Record.ExceptionAsync(() =>
+                {
+                    return steamClientApiClient.FindLeaderboardAsync(AppId, LeaderboardName);
+                });
+
+                // Assert
+                Assert.IsInstanceOfType(ex, typeof(SteamClientApiException));
+                var e = (SteamClientApiException)ex;
+                Assert.AreEqual(EResult.Fail, e.Result);
+            }
+
+            [TestMethod]
+            public async Task ResultIsOK_ReturnsLeaderboardEntriesCallback()
+            {
+                // Arrange
+                mockIFindOrCreateLeaderboardCallback
+                    .Setup(le => le.Result)
+                    .Returns(EResult.OK);
+
+                // Act
+                var leaderboardEntries = await steamClientApiClient.FindLeaderboardAsync(AppId, LeaderboardName);
+
+                // Assert
+                Assert.IsInstanceOfType(leaderboardEntries, typeof(IFindOrCreateLeaderboardCallback));
+            }
+        }
+
+        [TestClass]
+        public class GetLeaderboardEntriesAsync
+        {
+            const string UserName = "userName";
+            const string Password = "password";
+            const uint AppId = 247080;
+            const int LeaderboardId = 739999;
+
+            Mock<ILeaderboardEntriesCallback> mockILeaderboardEntriesCallback;
+            Mock<ISteamUserStats> mockISteamUserStats;
+            Mock<ISteamClient> mockISteamClient;
+            Mock<ICallbackManager> mockICallbackManager;
+            SteamClientApiClient steamClientApiClient;
+
+            [TestInitialize]
+            public void TestInitialize()
+            {
+                mockILeaderboardEntriesCallback = new Mock<ILeaderboardEntriesCallback>();
+
+                mockISteamUserStats = new Mock<ISteamUserStats>();
+                mockISteamUserStats
+                    .Setup(s => s.GetLeaderboardEntries(It.IsAny<uint>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<ELeaderboardDataRequest>()))
+                    .Returns(Task.FromResult(mockILeaderboardEntriesCallback.Object));
+
+                mockISteamClient = new Mock<ISteamClient>();
+                mockISteamClient
+                    .Setup(c => c.GetSteamUserStats())
+                    .Returns(mockISteamUserStats.Object);
+
+                mockICallbackManager = new Mock<ICallbackManager>();
+                mockICallbackManager
+                    .SetupGet(manager => manager.SteamClient)
+                    .Returns(mockISteamClient.Object);
+
+                steamClientApiClient = new SteamClientApiClient(UserName, Password, mockICallbackManager.Object);
+            }
+
+            [TestMethod]
+            public async Task ResultIsNotOK_ThrowsSteamClientApiException()
+            {
+                // Arrange
+                mockILeaderboardEntriesCallback
+                    .Setup(le => le.Result)
+                    .Returns(EResult.Fail);
+
+                // Act
+                var ex = await Record.ExceptionAsync(() =>
+                {
+                    return steamClientApiClient.GetLeaderboardEntriesAsync(AppId, LeaderboardId);
+                });
+
+                // Assert
+                Assert.IsInstanceOfType(ex, typeof(SteamClientApiException));
+                var e = (SteamClientApiException)ex;
+                Assert.AreEqual(EResult.Fail, e.Result);
+            }
+
+            [TestMethod]
+            public async Task ResultIsOK_ReturnsLeaderboardEntriesCallback()
+            {
+                // Arrange
+                mockILeaderboardEntriesCallback
+                    .Setup(le => le.Result)
+                    .Returns(EResult.OK);
+
+                // Act
+                var leaderboardEntries = await steamClientApiClient.GetLeaderboardEntriesAsync(AppId, LeaderboardId);
+
+                // Assert
+                Assert.IsInstanceOfType(leaderboardEntries, typeof(ILeaderboardEntriesCallback));
+            }
+        }
+    }
+}

--- a/toofz.NecroDancer.Leaderboards.Tests/Steam/ClientApi/SteamClientApiTransientErrorDetectionStrategyTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/Steam/ClientApi/SteamClientApiTransientErrorDetectionStrategyTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using toofz.NecroDancer.Leaderboards.Steam.ClientApi;
+
+namespace toofz.NecroDancer.Leaderboards.Tests.Steam.ClientApi
+{
+    class SteamClientApiTransientErrorDetectionStrategyTests
+    {
+        [TestClass]
+        public class IsTransient
+        {
+            [TestMethod]
+            public void ExIsSteamClientApiException_WithTaskCanceledExceptionAsInnerException_ReturnsTrue()
+            {
+                // Arrange
+                var strategy = new SteamClientApiTransientErrorDetectionStrategy();
+                var ex = new SteamClientApiException("message", new TaskCanceledException());
+
+                // Act
+                var isTransient = strategy.IsTransient(ex);
+
+                // Assert
+                Assert.IsTrue(isTransient);
+            }
+
+            [TestMethod]
+            public void ExIsSteamClientApiException_WithoutTaskCanceledExceptionAsInnerException_ReturnsFalse()
+            {
+                // Arrange
+                var strategy = new SteamClientApiTransientErrorDetectionStrategy();
+                var ex = new SteamClientApiException();
+
+                // Act
+                var isTransient = strategy.IsTransient(ex);
+
+                // Assert
+                Assert.IsFalse(isTransient);
+            }
+
+            [TestMethod]
+            public void ExIsNotTaskCanceledException_ReturnsFalse()
+            {
+                // Arrange
+                var strategy = new SteamClientApiTransientErrorDetectionStrategy();
+                var ex = new Exception();
+
+                // Act
+                var isTransient = strategy.IsTransient(ex);
+
+                // Assert
+                Assert.IsFalse(isTransient);
+            }
+        }
+    }
+}

--- a/toofz.NecroDancer.Leaderboards.Tests/Steam/WebApi/ISteamRemoteStorage/UgcFileDetailsTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/Steam/WebApi/ISteamRemoteStorage/UgcFileDetailsTests.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 using toofz.NecroDancer.Leaderboards.Steam.WebApi.ISteamRemoteStorage;
 using toofz.NecroDancer.Leaderboards.Tests.Properties;
 
-namespace toofz.NecroDancer.Leaderboards.Tests.SteamWebApi.ISteamRemoteStorage
+namespace toofz.NecroDancer.Leaderboards.Tests.Steam.WebApi.ISteamRemoteStorage
 {
     class UgcFileDetailsTests
     {

--- a/toofz.NecroDancer.Leaderboards.Tests/Steam/WebApi/ISteamUser/PlayerSummariesTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/Steam/WebApi/ISteamUser/PlayerSummariesTests.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 using toofz.NecroDancer.Leaderboards.Steam.WebApi.ISteamUser;
 using toofz.NecroDancer.Leaderboards.Tests.Properties;
 
-namespace toofz.NecroDancer.Leaderboards.Tests.SteamWebApi.ISteamUser
+namespace toofz.NecroDancer.Leaderboards.Tests.Steam.WebApi.ISteamUser
 {
     class PlayerSummariesTests
     {

--- a/toofz.NecroDancer.Leaderboards.Tests/Steam/WebApi/SteamWebApiClientTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/Steam/WebApi/SteamWebApiClientTests.cs
@@ -9,7 +9,7 @@ using toofz.NecroDancer.Leaderboards.Steam.WebApi.ISteamUser;
 using toofz.NecroDancer.Leaderboards.Tests.Properties;
 using toofz.TestsShared;
 
-namespace toofz.NecroDancer.Leaderboards.Tests.SteamWebApi
+namespace toofz.NecroDancer.Leaderboards.Tests.Steam.WebApi
 {
     class SteamWebApiClientTests
     {

--- a/toofz.NecroDancer.Leaderboards.Tests/StreamPipelineTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/StreamPipelineTests.cs
@@ -8,7 +8,7 @@ using toofz.TestsShared;
 
 namespace toofz.NecroDancer.Leaderboards.Tests
 {
-    public class StreamPipelineTests
+    class StreamPipelineTests
     {
         [TestClass]
         public class CreateRequestBlock

--- a/toofz.NecroDancer.Leaderboards.Tests/UgcHttpClientTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/UgcHttpClientTests.cs
@@ -12,7 +12,7 @@ namespace toofz.NecroDancer.Leaderboards.Tests
     class UgcHttpClientTests
     {
         [TestClass]
-        public class GetUgcFileAsyncTests
+        public class GetUgcFileAsync
         {
             [TestMethod]
             public async Task UrlIsNull_ThrowsArgumentNullException()

--- a/toofz.NecroDancer.Leaderboards.Tests/packages.config
+++ b/toofz.NecroDancer.Leaderboards.Tests/packages.config
@@ -13,7 +13,9 @@
   <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net45" />
   <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="RichardSzalay.MockHttp" version="1.5.0" targetFramework="net45" />
+  <package id="SteamKit2" version="1.8.3" targetFramework="net45" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net45" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net45" />
   <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net45" />

--- a/toofz.NecroDancer.Leaderboards.Tests/toofz.NecroDancer.Leaderboards.Tests.csproj
+++ b/toofz.NecroDancer.Leaderboards.Tests/toofz.NecroDancer.Leaderboards.Tests.csproj
@@ -80,8 +80,14 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
     <Reference Include="RichardSzalay.MockHttp, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RichardSzalay.MockHttp.1.5.0\lib\net45\RichardSzalay.MockHttp.dll</HintPath>
+    </Reference>
+    <Reference Include="SteamKit2, Version=1.8.3.0, Culture=neutral, PublicKeyToken=ed3ce47ed5aad940, processorArchitecture=MSIL">
+      <HintPath>..\packages\SteamKit2.1.8.3\lib\net45\SteamKit2.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -112,6 +118,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Steam\ClientApi\ProgressDebugNetworkListenerTests.cs" />
+    <Compile Include="Steam\ClientApi\SteamClientApiClientTests.cs" />
+    <Compile Include="Steam\ClientApi\SteamClientApiTransientErrorDetectionStrategyTests.cs" />
     <Compile Include="TestsSetup.cs" />
     <Compile Include="UgcHttpClientTests.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
@@ -138,11 +147,11 @@
     <None Include="Resources\GetUGCFileDetails.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="SteamWebApi\ISteamRemoteStorage\UgcFileDetailsTests.cs" />
-    <Compile Include="SteamWebApi\ISteamUser\PlayerSummariesTests.cs" />
+    <Compile Include="Steam\WebApi\ISteamRemoteStorage\UgcFileDetailsTests.cs" />
+    <Compile Include="Steam\WebApi\ISteamUser\PlayerSummariesTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="SteamWebApi\SteamWebApiClientTests.cs" />
+    <Compile Include="Steam\WebApi\SteamWebApiClientTests.cs" />
     <Compile Include="ApiClientTests.cs" />
     <Compile Include="ApiExceptionTests.cs" />
     <Compile Include="Constants.cs" />

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/CallbackManagerAdapter.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/CallbackManagerAdapter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Net.Sockets;
+using SteamKit2;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    sealed class CallbackManagerAdapter : ICallbackManager
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CallbackManagerAdapter"/> class.
+        /// </summary>
+        public CallbackManagerAdapter(ProtocolType type = ProtocolType.Tcp)
+        {
+            var steamClient = new SteamClient(type);
+            CallbackManager = new CallbackManager(steamClient);
+            SteamClient = new SteamClientAdapter(steamClient, this);
+        }
+
+        public CallbackManager CallbackManager { get; }
+        public ISteamClient SteamClient { get; }
+
+        /// <summary>
+        /// Blocks the current thread to run all queued callbacks. If no callback is queued,
+        /// the method will block for the given timeout.
+        /// </summary>
+        /// <param name="timeout">The length of time to block.</param>
+        public void RunWaitAllCallbacks(TimeSpan timeout)
+        {
+            CallbackManager.RunWaitAllCallbacks(timeout);
+        }
+
+        /// <summary>
+        /// Registers the provided <see cref="Action{TCallback}"/> to receive callbacks of type <typeparamref name="TCallback"/>.
+        /// </summary>
+        /// <typeparam name="TCallback"></typeparam>
+        /// <param name="callbackFunc">
+        /// The function to invoke with the callback.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IDisposable"/>. Disposing of the return value will unsubscribe the <paramref name="callbackFunc"/>.
+        /// </returns>
+        public IDisposable Subscribe<TCallback>(Action<TCallback> callbackFunc) where TCallback : class, ICallbackMsg
+        {
+            return CallbackManager.Subscribe(callbackFunc);
+        }
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/FindOrCreateLeaderboardCallbackAdapter.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/FindOrCreateLeaderboardCallbackAdapter.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using SteamKit2;
+using static SteamKit2.SteamUserStats;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    sealed class FindOrCreateLeaderboardCallbackAdapter : IFindOrCreateLeaderboardCallback
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FindOrCreateLeaderboardCallbackAdapter"/>.
+        /// </summary>
+        /// <param name="leaderboard">
+        /// The <see cref="FindOrCreateLeaderboardCallback"/> to wrap.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="leaderboard"/> is null.
+        /// </exception>
+        public FindOrCreateLeaderboardCallbackAdapter(FindOrCreateLeaderboardCallback leaderboard)
+        {
+            this.leaderboard = leaderboard ?? throw new ArgumentNullException(nameof(leaderboard), $"{nameof(leaderboard)} is null.");
+        }
+
+        readonly FindOrCreateLeaderboardCallback leaderboard;
+
+        /// <summary>
+        /// Gets the result of the request.
+        /// </summary>
+        public EResult Result => leaderboard.Result;
+
+        /// <summary>
+        /// Leaderboard ID.
+        /// </summary>
+        public int ID => leaderboard.ID;
+
+        /// <summary>
+        /// How many entires there are for requested leaderboard.
+        /// </summary>
+        public int EntryCount => leaderboard.EntryCount;
+
+        /// <summary>
+        /// Sort method to use for this leaderboard.
+        /// </summary>
+        public ELeaderboardSortMethod SortMethod => leaderboard.SortMethod;
+
+        /// <summary>
+        /// Display type for this leaderboard.
+        /// </summary>
+        public ELeaderboardDisplayType DisplayType => leaderboard.DisplayType;
+
+        /// <summary>
+        /// The <see cref="ICallbackMsg.JobID"/> that this callback is associated with. If there
+        /// is no job associated, then this will be <see cref="JobID.Invalid"/>
+        /// </summary>
+        public JobID JobID
+        {
+            get => leaderboard.JobID;
+            set => leaderboard.JobID = value;
+        }
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ICallbackManager.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ICallbackManager.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using SteamKit2;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    public interface ICallbackManager
+    {
+        ISteamClient SteamClient { get; }
+        /// <summary>
+        /// Blocks the current thread to run all queued callbacks. If no callback is queued,
+        /// the method will block for the given timeout.
+        /// </summary>
+        /// <param name="timeout">The length of time to block.</param>
+        void RunWaitAllCallbacks(TimeSpan timeout);
+        /// <summary>
+        /// Registers the provided <see cref="Action{TCallback}"/> to receive callbacks of type <typeparamref name="TCallback"/>.
+        /// </summary>
+        /// <typeparam name="TCallback"></typeparam>
+        /// <param name="callbackFunc">
+        /// The function to invoke with the callback.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IDisposable"/>. Disposing of the return value will unsubscribe the <paramref name="callbackFunc"/>.
+        /// </returns>
+        IDisposable Subscribe<TCallback>(Action<TCallback> callbackFunc) where TCallback : class, ICallbackMsg;
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/IFindOrCreateLeaderboardCallback.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/IFindOrCreateLeaderboardCallback.cs
@@ -1,0 +1,28 @@
+﻿using SteamKit2;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    public interface IFindOrCreateLeaderboardCallback : ICallbackMsg
+    {
+        /// <summary>
+        /// Gets the result of the request.
+        /// </summary>
+        EResult Result { get; }
+        /// <summary>
+        /// Leaderboard ID.
+        /// </summary>
+        int ID { get; }
+        /// <summary>
+        /// How many entires there are for requested leaderboard.
+        /// </summary>
+        int EntryCount { get; }
+        /// <summary>
+        /// Sort method to use for this leaderboard.
+        /// </summary>
+        ELeaderboardSortMethod SortMethod { get; }
+        /// <summary>
+        /// Display type for this leaderboard.
+        /// </summary>
+        ELeaderboardDisplayType DisplayType { get; }
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ILeaderboardEntriesCallback.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ILeaderboardEntriesCallback.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.ObjectModel;
+using SteamKit2;
+using static SteamKit2.SteamUserStats.LeaderboardEntriesCallback;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    public interface ILeaderboardEntriesCallback : ICallbackMsg
+    {
+        /// <summary>
+        /// Gets the result of the request.
+        /// </summary>
+        EResult Result { get; }
+        /// <summary>
+        /// How many entires there are for requested leaderboard.
+        /// </summary>
+        int EntryCount { get; }
+        /// <summary>
+        /// Gets the list of leaderboard entries this response contains.
+        /// </summary>
+        ReadOnlyCollection<LeaderboardEntry> Entries { get; }
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ISteamClient.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ISteamClient.cs
@@ -1,0 +1,52 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using SteamKit2;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    public interface ISteamClient
+    {
+        /// <summary>
+        /// Gets a value indicating whether this instance is connected to the remote CM server.
+        /// </summary>
+        bool IsConnected { get; }
+        /// <summary>
+        /// Gets a value indicating whether this instance is logged on to the remote CM server.
+        /// </summary>
+        bool IsLoggedOn { get; }
+        /// <summary>
+        /// Gets or sets the network listening interface. Use this for debugging only. For
+        /// your convenience, you can use <see cref="NetHookNetworkListener"/> class.
+        /// </summary>
+        ProgressDebugNetworkListener ProgressDebugNetworkListener { get; set; }
+        /// <summary>
+        /// Returns a wrapped registered handler for <see cref="SteamUserStats"/>.
+        /// </summary>
+        ISteamUserStats GetSteamUserStats();
+        /// <summary>
+        /// Connects this client to a Steam3 server. This begins the process of connecting
+        /// and encrypting the data channel between the client and the server. Results are
+        /// returned asynchronously in a <see cref="SteamClient.ConnectedCallback"/>. If the
+        /// server that SteamKit attempts to connect to is down, a <see cref="SteamClient.DisconnectedCallback"/>
+        /// will be posted instead. SteamKit will not attempt to reconnect to Steam, you
+        /// must handle this callback and call Connect again preferrably after a short delay.
+        /// </summary>
+        /// <param name="cmServer">
+        /// The <see cref="IPEndPoint"/> of the CM server to connect to. If null, SteamKit will
+        /// randomly select a CM server from its internal list.
+        /// </param>
+        Task<SteamClient.ConnectedCallback> ConnectAsync(IPEndPoint cmServer = null);
+        /// <summary>
+        /// Logs the client into the Steam3 network. The client should already have been
+        /// connected at this point. Results are returned in a <see cref="SteamUser.LoggedOnCallback"/>.
+        /// </summary>
+        /// <param name="details">The details to use for logging on.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// No logon details were provided.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        /// Username or password are not set within details.
+        /// </exception>
+        Task<SteamUser.LoggedOnCallback> LogOnAsync(SteamUser.LogOnDetails details);
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ISteamClientApiClient.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ISteamClientApiClient.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    public interface ISteamClientApiClient
+    {
+        IProgress<long> Progress { get; set; }
+
+        /// <summary>
+        /// Gets leaderboard entries for the specified AppID and leaderboard ID.
+        /// </summary>
+        /// <exception cref="SteamClientApiException">
+        /// Unable to retrieve entries for leaderboard.
+        /// </exception>
+        Task<IFindOrCreateLeaderboardCallback> FindLeaderboardAsync(
+            uint appId,
+            string name,
+            CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary>
+        /// Gets the leaderboard for the specified AppID and name.
+        /// </summary>
+        /// <exception cref="SteamClientApiException">
+        /// Unable to find the leaderboard.
+        /// </exception>
+        /// <exception cref="SteamClientApiException">
+        /// Unable to retrieve the leaderboard.
+        /// </exception>
+        Task<ILeaderboardEntriesCallback> GetLeaderboardEntriesAsync(
+            uint appId,
+            int lbid,
+            CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ISteamUserStats.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ISteamUserStats.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using SteamKit2;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    public interface ISteamUserStats
+    {
+        /// <summary>
+        /// Asks the Steam back-end for a leaderboard by name for a given appid. Results
+        /// are returned in a <see cref="IFindOrCreateLeaderboardCallback"/>.
+        /// </summary>
+        /// <param name="appId">The AppID to request a leaderboard for.</param>
+        /// <param name="name">Name of the leaderboard to request.</param>
+        Task<IFindOrCreateLeaderboardCallback> FindLeaderboard(uint appId, string name);
+        /// <summary>
+        /// Asks the Steam back-end for a set of rows in the leaderboard. Results are returned
+        /// in a <see cref="ILeaderboardEntriesCallback"/>.
+        /// </summary>
+        /// <param name="appId">The AppID to request leaderboard rows for.</param>
+        /// <param name="id">ID of the leaderboard to view.</param>
+        /// <param name="rangeStart">Range start or 0.</param>
+        /// <param name="rangeEnd">Range end or max leaderboard entries.</param>
+        /// <param name="dataRequest">Type of request.</param>
+        Task<ILeaderboardEntriesCallback> GetLeaderboardEntries(uint appId, int id, int rangeStart, int rangeEnd, ELeaderboardDataRequest dataRequest);
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/LeaderboardEntriesCallbackAdapter.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/LeaderboardEntriesCallbackAdapter.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using SteamKit2;
+using static SteamKit2.SteamUserStats;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    sealed class LeaderboardEntriesCallbackAdapter : ILeaderboardEntriesCallback
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeaderboardEntriesCallbackAdapter"/> class.
+        /// </summary>
+        /// <param name="leaderboardEntries">
+        /// The <see cref="LeaderboardEntriesCallback"/> instance to wrap.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="leaderboardEntries"/> is null.
+        /// </exception>
+        public LeaderboardEntriesCallbackAdapter(LeaderboardEntriesCallback leaderboardEntries)
+        {
+            this.leaderboardEntries = leaderboardEntries ?? throw new ArgumentNullException(nameof(leaderboardEntries), $"{nameof(leaderboardEntries)} is null.");
+        }
+
+        readonly LeaderboardEntriesCallback leaderboardEntries;
+
+        /// <summary>
+        /// Gets the result of the request.
+        /// </summary>
+        public EResult Result => leaderboardEntries.Result;
+
+        /// <summary>
+        /// How many entires there are for requested leaderboard.
+        /// </summary>
+        public int EntryCount => leaderboardEntries.EntryCount;
+
+        /// <summary>
+        /// Gets the list of leaderboard entries this response contains.
+        /// </summary>
+        public ReadOnlyCollection<LeaderboardEntriesCallback.LeaderboardEntry> Entries => leaderboardEntries.Entries;
+
+        /// <summary>
+        /// The <see cref="ICallbackMsg.JobID"/> that this callback is associated with. If there
+        /// is no job associated, then this will be <see cref="JobID.Invalid"/>
+        /// </summary>
+        public JobID JobID
+        {
+            get => leaderboardEntries.JobID;
+            set => leaderboardEntries.JobID = value;
+        }
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ProgressDebugNetworkListener.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/ProgressDebugNetworkListener.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using SteamKit2;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    public sealed class ProgressDebugNetworkListener : IDebugNetworkListener
+    {
+        public IProgress<long> Progress { get; set; }
+
+        /// <summary>
+        /// Called when a packet is received from the Steam server
+        /// </summary>
+        /// <param name="msgType">Network message type of this packet message.</param>
+        /// <param name="data">Raw packet data that was received.</param>
+        public void OnIncomingNetworkMessage(EMsg msgType, byte[] data)
+        {
+            Progress?.Report(data.Length);
+        }
+
+        /// <summary>
+        /// Called when a packet is about to be sent to the Steam server.
+        /// </summary>
+        /// <param name="msgType">Network message type of this packet message.</param>
+        /// <param name="data">Raw packet data that will be sent.</param>
+        public void OnOutgoingNetworkMessage(EMsg msgType, byte[] data)
+        {
+            // Do nothing
+        }
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamClientAdapter.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamClientAdapter.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using log4net;
+using SteamKit2;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    /// <summary>
+    /// Wraps an instance of <see cref="SteamClient"/> and presents a testable interface through <see cref="ISteamClient"/>.
+    /// </summary>
+    sealed class SteamClientAdapter : ISteamClient
+    {
+        static readonly ILog Log = LogManager.GetLogger(typeof(SteamClientAdapter));
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SteamClientAdapter"/> class.
+        /// </summary>
+        /// <param name="steamClient">
+        /// The instance of <see cref="SteamClient"/> to wrap.
+        /// </param>
+        /// <param name="manager">
+        /// The callback manager associated with <paramref name="steamClient"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="steamClient"/> is null.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="manager"/> is null.
+        /// </exception>
+        public SteamClientAdapter(SteamClient steamClient, ICallbackManager manager)
+        {
+            SteamClient = steamClient ?? throw new ArgumentNullException(nameof(steamClient), $"{nameof(steamClient)} is null.");
+            this.manager = manager ?? throw new ArgumentNullException(nameof(manager), $"{nameof(manager)} is null.");
+        }
+
+        readonly ICallbackManager manager;
+
+        /// <summary>
+        /// The instance of <see cref="SteamClient"/> wrapped by the adapter.
+        /// </summary>
+        public SteamClient SteamClient { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is connected to the remote CM server.
+        /// </summary>
+        public bool IsConnected => SteamClient.IsConnected;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is logged on to the remote CM server.
+        /// </summary>
+        public bool IsLoggedOn => SteamClient.SessionID != null;
+
+        /// <summary>
+        /// Gets or sets the network listening interface. Use this for debugging only. For
+        /// your convenience, you can use <see cref="NetHookNetworkListener"/> class.
+        /// </summary>
+        public ProgressDebugNetworkListener ProgressDebugNetworkListener
+        {
+            get => SteamClient.DebugNetworkListener as ProgressDebugNetworkListener;
+            set => SteamClient.DebugNetworkListener = value;
+        }
+
+        /// <summary>
+        /// Returns a registered handler.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the handler to cast to. Must derive from <see cref="ClientMsgHandler"/>.
+        /// </typeparam>
+        /// <returns>
+        /// A registered handler on success, or null if the handler could not be found.
+        /// </returns>
+        public T GetHandler<T>() where T : ClientMsgHandler
+        {
+            return SteamClient.GetHandler<T>();
+        }
+
+        /// <summary>
+        /// Returns a wrapped registered handler for <see cref="SteamUserStats"/>.
+        /// </summary>
+        public ISteamUserStats GetSteamUserStats()
+        {
+            var steamUserStats = SteamClient.GetHandler<SteamUserStats>();
+
+            return new SteamUserStatsAdapter(steamUserStats);
+        }
+
+        /// <summary>
+        /// Connects this client to a Steam3 server. This begins the process of connecting
+        /// and encrypting the data channel between the client and the server. Results are
+        /// returned asynchronously in a <see cref="SteamClient.ConnectedCallback"/>. If the
+        /// server that SteamKit attempts to connect to is down, a <see cref="SteamClient.DisconnectedCallback"/>
+        /// will be posted instead. SteamKit will not attempt to reconnect to Steam, you
+        /// must handle this callback and call Connect again preferrably after a short delay.
+        /// </summary>
+        /// <param name="cmServer">
+        /// The <see cref="IPEndPoint"/> of the CM server to connect to. If null, SteamKit will
+        /// randomly select a CM server from its internal list.
+        /// </param>
+        public Task<SteamClient.ConnectedCallback> ConnectAsync(IPEndPoint cmServer = null)
+        {
+            var tcs = new TaskCompletionSource<SteamClient.ConnectedCallback>();
+
+            IDisposable onConnected = null;
+            IDisposable onDisconnected = null;
+            onConnected = manager.Subscribe<SteamClient.ConnectedCallback>(response =>
+            {
+                switch (response.Result)
+                {
+                    case EResult.OK:
+                        Log.Info("Connected to Steam.");
+                        tcs.TrySetResult(response);
+                        break;
+                    default:
+                        tcs.TrySetException(new SteamClientApiException($"Unable to connect to Steam.") { Result = response.Result });
+                        break;
+                }
+
+                onConnected.Dispose();
+                onDisconnected.Dispose();
+            });
+            onDisconnected = manager.Subscribe<SteamClient.DisconnectedCallback>(response =>
+            {
+                tcs.TrySetException(new SteamClientApiException("Unable to connect to Steam."));
+                onConnected.Dispose();
+                onDisconnected.Dispose();
+            });
+
+            SteamClient.Connect(cmServer);
+            manager.RunWaitAllCallbacks(TimeSpan.FromSeconds(1));
+
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// Logs the client into the Steam3 network. The client should already have been
+        /// connected at this point. Results are returned in a <see cref="SteamUser.LoggedOnCallback"/>.
+        /// </summary>
+        /// <param name="details">The details to use for logging on.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// No logon details were provided.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        /// Username or password are not set within details.
+        /// </exception>
+        public Task<SteamUser.LoggedOnCallback> LogOnAsync(SteamUser.LogOnDetails details)
+        {
+            var tcs = new TaskCompletionSource<SteamUser.LoggedOnCallback>();
+
+            IDisposable onLoggedOn = null;
+            IDisposable onDisconnected = null;
+            onLoggedOn = manager.Subscribe<SteamUser.LoggedOnCallback>(response =>
+            {
+                switch (response.Result)
+                {
+                    case EResult.OK:
+                        Log.Info("Logged on to Steam.");
+                        tcs.TrySetResult(response);
+                        break;
+                    case EResult.AccountLogonDenied:
+                        {
+                            var ex = new SteamClientApiException("Unable to logon to Steam: This account is SteamGuard protected.") { Result = response.Result };
+                            tcs.TrySetException(ex);
+                            break;
+                        }
+                    default:
+                        {
+                            var ex = new SteamClientApiException("Unable to logon to Steam.") { Result = response.Result };
+                            tcs.TrySetException(ex);
+                            break;
+                        }
+                }
+
+                onLoggedOn.Dispose();
+                onDisconnected.Dispose();
+            });
+            onDisconnected = manager.Subscribe<SteamClient.DisconnectedCallback>(response =>
+            {
+                tcs.TrySetException(new SteamClientApiException("Unable to connect to Steam."));
+                onLoggedOn.Dispose();
+                onDisconnected.Dispose();
+            });
+
+            GetHandler<SteamUser>().LogOn(details);
+            manager.RunWaitAllCallbacks(TimeSpan.FromSeconds(1));
+
+            return tcs.Task;
+        }
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamClientApiClient.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamClientApiClient.cs
@@ -1,157 +1,80 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using log4net;
+using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
 using SteamKit2;
 
 namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
 {
-    public sealed class SteamClientApiClient
+    public sealed class SteamClientApiClient : ISteamClientApiClient
     {
         static readonly ILog Log = LogManager.GetLogger(typeof(SteamClientApiClient));
 
-        const int AppId = 247080;
-        const int EntriesPerRequest = 1000000;
+        static readonly RetryStrategy RetryStrategy = new ExponentialBackoff(10, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(2));
+        static readonly RetryPolicy<SteamClientApiTransientErrorDetectionStrategy> RetryPolicy = SteamClientApiTransientErrorDetectionStrategy.Create(RetryStrategy);
 
-        public SteamClientApiClient()
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SteamClientApiClient"/> class 
+        /// with the specified user name and password.
+        /// </summary>
+        /// <param name="userName">The user name to log on to Steam with.</param>
+        /// <param name="password">The password to log on to Steam with.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// <paramref name="userName"/> is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// <paramref name="password"/> is null.
+        /// </exception>
+        public SteamClientApiClient(string userName, string password, ICallbackManager manager = null)
         {
-            categories = LeaderboardsResources.ReadCategories("leaderboard-categories.min.json");
+            this.userName = userName ?? throw new ArgumentNullException(nameof(userName), $"{nameof(userName)} is null.");
+            this.password = password ?? throw new ArgumentNullException(nameof(password), $"{nameof(password)} is null.");
 
-            User = Util.GetEnvVar("SteamUserName");
-            Pass = Util.GetEnvVar("SteamPassword");
+            manager = manager ?? new CallbackManagerAdapter();
+            manager.SteamClient.ProgressDebugNetworkListener = new ProgressDebugNetworkListener();
 
-            networkListener = new ProgressDebugNetworkListener();
-            steamClient = new SteamClient { DebugNetworkListener = networkListener };
-            manager = new CallbackManager(steamClient);
-            steamUser = steamClient.GetHandler<SteamUser>();
-            steamUserStats = steamClient.GetHandler<SteamUserStats>();
-
-            manager.Subscribe<SteamUser.LoggedOffCallback>(response =>
-            {
-                Log.Info("Logged off from Steam.");
-            });
+            steamClient = manager.SteamClient;
+            steamUserStats = steamClient.GetSteamUserStats();
         }
 
-        readonly Categories categories;
-        readonly string User;
-        readonly string Pass;
-        readonly ProgressDebugNetworkListener networkListener;
-        readonly SteamClient steamClient;
-        readonly CallbackManager manager;
-        readonly SteamUser steamUser;
-        readonly SteamUserStats steamUserStats;
+        readonly string userName;
+        readonly string password;
+        readonly ISteamClient steamClient;
+        readonly ISteamUserStats steamUserStats;
 
         public IProgress<long> Progress
         {
-            get { return networkListener.Progress; }
-            set { networkListener.Progress = value; }
+            get => steamClient.ProgressDebugNetworkListener?.Progress;
+            set
+            {
+                if (steamClient.ProgressDebugNetworkListener == null)
+                    throw new InvalidOperationException($"{nameof(steamClient)}.{nameof(steamClient.ProgressDebugNetworkListener)} is null.");
+
+                steamClient.ProgressDebugNetworkListener.Progress = value;
+            }
         }
 
-        Task<SteamClient.ConnectedCallback> ConnectAsync()
-        {
-            var tcs = new TaskCompletionSource<SteamClient.ConnectedCallback>();
-
-            IDisposable onConnected = null;
-            IDisposable onDisconnected = null;
-            onConnected = manager.Subscribe<SteamClient.ConnectedCallback>(response =>
-            {
-                switch (response.Result)
-                {
-                    case EResult.OK:
-                        Log.Info("Connected to Steam.");
-                        tcs.TrySetResult(response);
-                        break;
-                    default:
-                        tcs.TrySetException(new SteamClientApiException($"Unable to connect to Steam.") { Result = response.Result });
-                        break;
-                }
-
-                onConnected.Dispose();
-                onDisconnected.Dispose();
-            });
-            onDisconnected = manager.Subscribe<SteamClient.DisconnectedCallback>(response =>
-            {
-                tcs.TrySetException(new SteamClientApiException("Unable to connect to Steam."));
-                onConnected.Dispose();
-                onDisconnected.Dispose();
-            });
-
-            steamClient.Connect();
-            manager.RunWaitAllCallbacks(TimeSpan.FromSeconds(1));
-
-            return tcs.Task;
-        }
-
-        Task<SteamUser.LoggedOnCallback> LogOnAsync()
-        {
-            var tcs = new TaskCompletionSource<SteamUser.LoggedOnCallback>();
-
-            IDisposable onLoggedOn = null;
-            IDisposable onDisconnected = null;
-            onLoggedOn = manager.Subscribe<SteamUser.LoggedOnCallback>(response =>
-            {
-                switch (response.Result)
-                {
-                    case EResult.OK:
-                        Log.Info("Logged on to Steam.");
-                        tcs.TrySetResult(response);
-                        break;
-                    case EResult.AccountLogonDenied:
-                        {
-                            var ex = new SteamClientApiException("Unable to logon to Steam: This account is SteamGuard protected.")
-                            {
-                                Result = response.Result
-                            };
-                            tcs.TrySetException(ex);
-                            break;
-                        }
-                    default:
-                        {
-                            var ex = new SteamClientApiException("Unable to logon to Steam.")
-                            {
-                                Result = response.Result
-                            };
-                            tcs.TrySetException(ex);
-                            break;
-                        }
-                }
-
-                onLoggedOn.Dispose();
-                onDisconnected.Dispose();
-            });
-            onDisconnected = manager.Subscribe<SteamClient.DisconnectedCallback>(response =>
-            {
-                tcs.TrySetException(new SteamClientApiException("Unable to connect to Steam."));
-                onLoggedOn.Dispose();
-                onDisconnected.Dispose();
-            });
-
-            steamUser.LogOn(new SteamUser.LogOnDetails
-            {
-                Username = User,
-                Password = Pass,
-            });
-            manager.RunWaitAllCallbacks(TimeSpan.FromSeconds(1));
-
-            return tcs.Task;
-        }
+        #region Connection
 
         static readonly SemaphoreSlim connectAndLogOnSemaphore = new SemaphoreSlim(1, 1);
 
-        async Task ConnectAndLogOnAsync()
+        internal async Task ConnectAndLogOnAsync(CancellationToken cancellationToken)
         {
-            await connectAndLogOnSemaphore.WaitAsync();
+            await connectAndLogOnSemaphore.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
             try
             {
                 if (!steamClient.IsConnected)
                 {
-                    await ConnectAsync().ConfigureAwait(false);
+                    await steamClient.ConnectAsync().ConfigureAwait(false);
                 }
-                if (steamClient.SessionID == null)
+                if (!steamClient.IsLoggedOn)
                 {
-                    await LogOnAsync().ConfigureAwait(false);
+                    await steamClient.LogOnAsync(new SteamUser.LogOnDetails
+                    {
+                        Username = userName,
+                        Password = password,
+                    }).ConfigureAwait(false);
                 }
             }
             finally
@@ -160,197 +83,82 @@ namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
             }
         }
 
-        public async Task<Leaderboard> GetLeaderboardAsync(LeaderboardHeader header)
+        #endregion
+
+        /// <summary>
+        /// Gets the leaderboard for the specified AppID and name.
+        /// </summary>
+        /// <exception cref="SteamClientApiException">
+        /// Unable to find the leaderboard.
+        /// </exception>
+        /// <exception cref="SteamClientApiException">
+        /// Unable to retrieve the leaderboard.
+        /// </exception>
+        public async Task<IFindOrCreateLeaderboardCallback> FindLeaderboardAsync(
+            uint appId,
+            string name,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            await ConnectAndLogOnAsync().ConfigureAwait(false);
+            await ConnectAndLogOnAsync(cancellationToken).ConfigureAwait(false);
 
-            var lbid = header.id;
-
-            var leaderboard = new Leaderboard
-            {
-                LeaderboardId = lbid,
-                CharacterId = categories.GetItemId("characters", header.character),
-                RunId = categories.GetItemId("runs", header.run),
-                LastUpdate = DateTime.UtcNow,
-            };
-
-            try
-            {
-                var response = await steamUserStats
-                    .GetLeaderboardEntries(AppId, lbid, 0, EntriesPerRequest, ELeaderboardDataRequest.Global)
-                    .ToTask()
-                    .ConfigureAwait(false);
-
-                switch (response.Result)
+            var leaderboard =
+                await RetryPolicy.ExecuteAsync(async () =>
                 {
-                    case EResult.OK:
-                        {
-                            leaderboard.EntriesCount = response.EntryCount;
-                            var entries = response.Entries.Select(e =>
-                            {
-                                var entry = new Entry
-                                {
-                                    LeaderboardId = lbid,
-                                    Rank = e.GlobalRank,
-                                    SteamId = (long)(ulong)e.SteamID,
-                                    Score = e.Score,
-                                    Zone = e.Details[0],
-                                    Level = e.Details[1],
-                                };
-                                var ugcId = (long)(ulong)e.UGCId;
-                                switch (ugcId)
-                                {
-                                    case -1: entry.ReplayId = null; break;
-                                    default: entry.ReplayId = ugcId; break;
-                                }
+                    try
+                    {
+                        return await steamUserStats
+                            .FindLeaderboard(appId, name)
+                            .ConfigureAwait(false);
+                    }
+                    catch (TaskCanceledException ex)
+                    {
+                        throw new SteamClientApiException($"Unable to find the leaderboard '{name}' due to timeout.", ex);
+                    }
+                }, cancellationToken)
+                .ConfigureAwait(false);
 
-                                return entry;
-                            });
-                            leaderboard.Entries.AddRange(entries);
-
-                            return leaderboard;
-                        }
-                    default:
-                        throw new SteamClientApiException($"Unable to retrieve entries for leaderboard '{lbid}'.")
-                        {
-                            Result = response.Result
-                        };
-                }
-
-            }
-            catch (TaskCanceledException ex)
+            switch (leaderboard.Result)
             {
-                throw new SteamClientApiException($"Unable to retrieve entries for leaderboard '{lbid}'.", ex);
-            }
-        }
-
-        public async Task<DailyLeaderboard> GetDailyLeaderboardAsync(DailyLeaderboardHeader header)
-        {
-            await ConnectAndLogOnAsync().ConfigureAwait(false);
-
-            var lbid = header.id;
-
-            var leaderboard = new DailyLeaderboard
-            {
-                LeaderboardId = lbid,
-                Date = header.date,
-                ProductId = categories.GetItemId("products", header.product),
-                IsProduction = header.production,
-            };
-
-            try
-            {
-                var response = await steamUserStats
-                    .GetLeaderboardEntries(AppId, lbid, 0, EntriesPerRequest, ELeaderboardDataRequest.Global)
-                    .ToTask()
-                    .ConfigureAwait(false);
-
-                switch (response.Result)
-                {
-                    case EResult.OK:
-                        {
-                            leaderboard.LastUpdate = DateTime.UtcNow;
-
-                            var entries = response.Entries.Select(e =>
-                            {
-                                var entry = new DailyEntry
-                                {
-                                    LeaderboardId = lbid,
-                                    Rank = e.GlobalRank,
-                                    SteamId = (long)(ulong)e.SteamID,
-                                    Score = e.Score,
-                                    Zone = e.Details[0],
-                                    Level = e.Details[1],
-                                };
-                                var ugcId = (long)(ulong)e.UGCId;
-                                switch (ugcId)
-                                {
-                                    case -1: entry.ReplayId = null; break;
-                                    default: entry.ReplayId = ugcId; break;
-                                }
-
-                                return entry;
-                            });
-                            leaderboard.Entries.AddRange(entries);
-
-                            return leaderboard;
-                        }
-                    default:
-                        throw new SteamClientApiException($"Unable to retrieve entries for leaderboard '{lbid}'.")
-                        {
-                            Result = response.Result
-                        };
-                }
-            }
-            catch (TaskCanceledException ex)
-            {
-                throw new SteamClientApiException($"Unable to retrieve entries for leaderboard '{lbid}'.", ex);
-            }
-        }
-
-        public async Task<DailyLeaderboardHeader> GetDailyLeaderboardHeaderAsync(DateTime date, string product, bool isProduction)
-        {
-            await ConnectAndLogOnAsync().ConfigureAwait(false);
-
-            var header = new DailyLeaderboardHeader
-            {
-                date = date,
-                product = product,
-                production = isProduction,
-            };
-
-            var tokens = new List<string>();
-
-            switch (product)
-            {
-                case "amplified": tokens.Add("DLC"); break;
-                case "classic": break;
+                case EResult.OK: return leaderboard;
                 default:
-                    throw new ArgumentException($"'{product}' is not a valid product.");
-            }
-
-            tokens.Add(date.ToString("d/M/yyyy"));
-
-            var name = string.Join(" ", tokens);
-            if (isProduction) { name += "_PROD"; }
-
-            try
-            {
-                var response = await steamUserStats
-                    .FindLeaderboard(AppId, name)
-                    .ToTask()
-                    .ConfigureAwait(false);
-
-                switch (response.Result)
-                {
-                    case EResult.OK: header.id = response.ID; break;
-                    default:
-                        throw new SteamClientApiException($"Unable to find the leaderboard '{name}'.")
-                        {
-                            Result = response.Result
-                        };
-                }
-
-                return header;
-            }
-            catch (TaskCanceledException ex)
-            {
-                throw new SteamClientApiException($"Unable to retrieve data for the leaderboard '{name}'.", ex);
+                    throw new SteamClientApiException($"Unable to find the leaderboard '{name}'.") { Result = leaderboard.Result };
             }
         }
 
-        class ProgressDebugNetworkListener : IDebugNetworkListener
+        /// <summary>
+        /// Gets leaderboard entries for the specified AppID and leaderboard ID.
+        /// </summary>
+        /// <exception cref="SteamClientApiException">
+        /// Unable to retrieve entries for leaderboard.
+        /// </exception>
+        public async Task<ILeaderboardEntriesCallback> GetLeaderboardEntriesAsync(
+            uint appId,
+            int lbid,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            public IProgress<long> Progress { get; set; }
+            await ConnectAndLogOnAsync(cancellationToken).ConfigureAwait(false);
 
-            public void OnIncomingNetworkMessage(EMsg msgType, byte[] data)
-            {
-                Progress?.Report(data.Length);
-            }
+            var leaderboardEntries =
+                await RetryPolicy.ExecuteAsync(async () =>
+                {
+                    try
+                    {
+                        return await steamUserStats
+                            .GetLeaderboardEntries(appId, lbid, 0, int.MaxValue, ELeaderboardDataRequest.Global)
+                            .ConfigureAwait(false);
+                    }
+                    catch (TaskCanceledException ex)
+                    {
+                        throw new SteamClientApiException($"Unable to retrieve entries for leaderboard '{lbid}' due to timeout.", ex);
+                    }
+                }, cancellationToken)
+                .ConfigureAwait(false);
 
-            public void OnOutgoingNetworkMessage(EMsg msgType, byte[] data)
+            switch (leaderboardEntries.Result)
             {
-                // Do nothing
+                case EResult.OK: return leaderboardEntries;
+                default:
+                    throw new SteamClientApiException($"Unable to retrieve entries for leaderboard '{lbid}'.") { Result = leaderboardEntries.Result };
             }
         }
     }

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamClientApiClient.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamClientApiClient.cs
@@ -20,6 +20,10 @@ namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
         /// </summary>
         /// <param name="userName">The user name to log on to Steam with.</param>
         /// <param name="password">The password to log on to Steam with.</param>
+        /// <param name="manager">
+        /// The callback manager associated with this instance. If <paramref name="manager"/> is null, a default callback manager 
+        /// will be created.
+        /// </param>
         /// <exception cref="System.ArgumentNullException">
         /// <paramref name="userName"/> is null.
         /// </exception>

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamClientApiTransientErrorDetectionStrategy.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamClientApiTransientErrorDetectionStrategy.cs
@@ -5,7 +5,7 @@ using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
 
 namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
 {
-    class SteamClientApiTransientErrorDetectionStrategy : ITransientErrorDetectionStrategy
+    sealed class SteamClientApiTransientErrorDetectionStrategy : ITransientErrorDetectionStrategy
     {
         #region Static Members
 
@@ -28,6 +28,14 @@ namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
 
         #region ITransientErrorDetectionStrategy Members
 
+        /// <summary>
+        /// Determines whether the specified exception represents a transient failure that
+        /// can be compensated by a retry.
+        /// </summary>
+        /// <param name="ex">The exception object to be verified.</param>
+        /// <returns>
+        /// true if the specified exception is considered as transient; otherwise, false.
+        /// </returns>
         public bool IsTransient(Exception ex)
         {
             var transient = ex as SteamClientApiException;

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamUserStatsAdapter.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamUserStatsAdapter.cs
@@ -40,7 +40,7 @@ namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
 
         /// <summary>
         /// Asks the Steam back-end for a set of rows in the leaderboard. Results are returned
-        /// in a <see cref="LeaderboardEntriesCallback"/>.
+        /// in a <see cref="ILeaderboardEntriesCallback"/>.
         /// </summary>
         /// <param name="appId">The AppID to request leaderboard rows for.</param>
         /// <param name="id">ID of the leaderboard to view.</param>

--- a/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamUserStatsAdapter.cs
+++ b/toofz.NecroDancer.Leaderboards/Steam/ClientApi/SteamUserStatsAdapter.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading.Tasks;
+using SteamKit2;
+
+namespace toofz.NecroDancer.Leaderboards.Steam.ClientApi
+{
+    sealed class SteamUserStatsAdapter : ISteamUserStats
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SteamUserStatsAdapter"/> class.
+        /// </summary>
+        /// <param name="steamUserStats">
+        /// The <see cref="SteamUserStats"/> instance to wrap.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="steamUserStats"/> is null.
+        /// </exception>
+        public SteamUserStatsAdapter(SteamUserStats steamUserStats)
+        {
+            this.steamUserStats = steamUserStats ?? throw new ArgumentNullException(nameof(steamUserStats), $"{nameof(steamUserStats)} is null.");
+        }
+
+        readonly SteamUserStats steamUserStats;
+
+        /// <summary>
+        /// Asks the Steam back-end for a leaderboard by name for a given appid. Results
+        /// are returned in a <see cref="IFindOrCreateLeaderboardCallback"/>.
+        /// </summary>
+        /// <param name="appId">The AppID to request a leaderboard for.</param>
+        /// <param name="name">Name of the leaderboard to request.</param>
+        public async Task<IFindOrCreateLeaderboardCallback> FindLeaderboard(uint appId, string name)
+        {
+            var leaderboard = await steamUserStats
+                .FindLeaderboard(appId, name)
+                .ToTask()
+                .ConfigureAwait(false);
+
+            return new FindOrCreateLeaderboardCallbackAdapter(leaderboard);
+        }
+
+        /// <summary>
+        /// Asks the Steam back-end for a set of rows in the leaderboard. Results are returned
+        /// in a <see cref="LeaderboardEntriesCallback"/>.
+        /// </summary>
+        /// <param name="appId">The AppID to request leaderboard rows for.</param>
+        /// <param name="id">ID of the leaderboard to view.</param>
+        /// <param name="rangeStart">Range start or 0.</param>
+        /// <param name="rangeEnd">Range end or max leaderboard entries.</param>
+        /// <param name="dataRequest">Type of request.</param>
+        public async Task<ILeaderboardEntriesCallback> GetLeaderboardEntries(uint appId, int id, int rangeStart, int rangeEnd, ELeaderboardDataRequest dataRequest)
+        {
+            var leaderboardEntries = await steamUserStats
+                .GetLeaderboardEntries(appId, id, rangeStart, rangeEnd, dataRequest)
+                .ToTask()
+                .ConfigureAwait(false);
+
+            return new LeaderboardEntriesCallbackAdapter(leaderboardEntries);
+        }
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/toofz.NecroDancer.Leaderboards.csproj
+++ b/toofz.NecroDancer.Leaderboards/toofz.NecroDancer.Leaderboards.csproj
@@ -112,9 +112,33 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Steam\ClientApi\SteamClientApiClient.cs" />
+    <Compile Include="Steam\ClientApi\CallbackManagerAdapter.cs">
+      <DependentUpon>ICallbackManager.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Steam\ClientApi\FindOrCreateLeaderboardCallbackAdapter.cs">
+      <DependentUpon>IFindOrCreateLeaderboardCallback.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Steam\ClientApi\ICallbackManager.cs" />
+    <Compile Include="Steam\ClientApi\IFindOrCreateLeaderboardCallback.cs" />
+    <Compile Include="Steam\ClientApi\ILeaderboardEntriesCallback.cs" />
+    <Compile Include="Steam\ClientApi\ISteamClient.cs" />
+    <Compile Include="Steam\ClientApi\ISteamClientApiClient.cs" />
+    <Compile Include="Steam\ClientApi\ISteamUserStats.cs" />
+    <Compile Include="Steam\ClientApi\LeaderboardEntriesCallbackAdapter.cs">
+      <DependentUpon>ILeaderboardEntriesCallback.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Steam\ClientApi\ProgressDebugNetworkListener.cs" />
+    <Compile Include="Steam\ClientApi\SteamClientAdapter.cs">
+      <DependentUpon>ISteamClient.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Steam\ClientApi\SteamClientApiClient.cs">
+      <DependentUpon>ISteamClientApiClient.cs</DependentUpon>
+    </Compile>
     <Compile Include="Steam\ClientApi\SteamClientApiException.cs" />
     <Compile Include="Steam\ClientApi\SteamClientApiTransientErrorDetectionStrategy.cs" />
+    <Compile Include="Steam\ClientApi\SteamUserStatsAdapter.cs">
+      <DependentUpon>ISteamUserStats.cs</DependentUpon>
+    </Compile>
     <Compile Include="Steam\WebApi\ISteamRemoteStorage\UgcFileDetails.cs" />
     <Compile Include="Steam\WebApi\ISteamUser\PlayerSummaries.cs" />
     <Compile Include="Steam\WebApi\ISteamWebApiClient.cs" />


### PR DESCRIPTION
* `SteamClientApiClient`
  * No longer transforms API responses into model objects (moved to `LeaderboardsClient`).
  * Async wrappers for connecting and logging in have been moved to `SteamClientAdapter`.
* `LeaderboardsClient`
  * No longer handles automatic retries on failed requests to the Steam Client API (moved to `SteamClientApiClient`).
* Added adapter types for SteamKit types to enable testing.