### PR TITLE
Improve API error handling

### DIFF
--- a/toofz.NecroDancer.Leaderboards.Services.Common/packages.config
+++ b/toofz.NecroDancer.Leaderboards.Services.Common/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
-  <package id="toofz" version="2.1.0" targetFramework="net45" />
+  <package id="toofz" version="2.2.0" targetFramework="net45" />
 </packages>

--- a/toofz.NecroDancer.Leaderboards.Services.Common/toofz.NecroDancer.Leaderboards.Services.Common.csproj
+++ b/toofz.NecroDancer.Leaderboards.Services.Common/toofz.NecroDancer.Leaderboards.Services.Common.csproj
@@ -62,8 +62,8 @@
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceProcess" />
-    <Reference Include="toofz, Version=2.1.0.20911, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\toofz.2.1.0\lib\net45\toofz.dll</HintPath>
+    <Reference Include="toofz, Version=2.2.0.19639, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\toofz.2.2.0\lib\net45\toofz.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/toofz.NecroDancer.Leaderboards.Services.LeaderboardsService/packages.config
+++ b/toofz.NecroDancer.Leaderboards.Services.LeaderboardsService/packages.config
@@ -12,5 +12,5 @@
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="SteamKit2" version="1.8.3" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
-  <package id="toofz" version="2.1.0" targetFramework="net45" />
+  <package id="toofz" version="2.2.0" targetFramework="net45" />
 </packages>

--- a/toofz.NecroDancer.Leaderboards.Services.LeaderboardsService/toofz.NecroDancer.Leaderboards.Services.LeaderboardsService.csproj
+++ b/toofz.NecroDancer.Leaderboards.Services.LeaderboardsService/toofz.NecroDancer.Leaderboards.Services.LeaderboardsService.csproj
@@ -88,8 +88,8 @@
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceProcess" />
-    <Reference Include="toofz, Version=2.1.0.20911, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\toofz.2.1.0\lib\net45\toofz.dll</HintPath>
+    <Reference Include="toofz, Version=2.2.0.19639, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\toofz.2.2.0\lib\net45\toofz.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/toofz.NecroDancer.Leaderboards.Services.PlayersService/packages.config
+++ b/toofz.NecroDancer.Leaderboards.Services.PlayersService/packages.config
@@ -11,5 +11,5 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
-  <package id="toofz" version="2.1.0" targetFramework="net45" />
+  <package id="toofz" version="2.2.0" targetFramework="net45" />
 </packages>

--- a/toofz.NecroDancer.Leaderboards.Services.PlayersService/toofz.NecroDancer.Leaderboards.Services.PlayersService.csproj
+++ b/toofz.NecroDancer.Leaderboards.Services.PlayersService/toofz.NecroDancer.Leaderboards.Services.PlayersService.csproj
@@ -83,8 +83,8 @@
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.ServiceProcess" />
-    <Reference Include="toofz, Version=2.1.0.20911, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\toofz.2.1.0\lib\net45\toofz.dll</HintPath>
+    <Reference Include="toofz, Version=2.2.0.19639, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\toofz.2.2.0\lib\net45\toofz.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/toofz.NecroDancer.Leaderboards.Services.ReplaysService/packages.config
+++ b/toofz.NecroDancer.Leaderboards.Services.ReplaysService/packages.config
@@ -21,7 +21,7 @@
   <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net45" />
   <package id="System.Net.Requests" version="4.3.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.8.2" targetFramework="net45" />
-  <package id="toofz" version="2.1.0" targetFramework="net45" />
+  <package id="toofz" version="2.2.0" targetFramework="net45" />
   <package id="toofz.NecroDancer" version="2.0.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="8.2.1" targetFramework="net45" />
 </packages>

--- a/toofz.NecroDancer.Leaderboards.Services.ReplaysService/toofz.NecroDancer.Leaderboards.Services.ReplaysService.csproj
+++ b/toofz.NecroDancer.Leaderboards.Services.ReplaysService/toofz.NecroDancer.Leaderboards.Services.ReplaysService.csproj
@@ -95,8 +95,8 @@
     <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
-    <Reference Include="toofz, Version=2.1.0.20911, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\toofz.2.1.0\lib\net45\toofz.dll</HintPath>
+    <Reference Include="toofz, Version=2.2.0.19639, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\toofz.2.2.0\lib\net45\toofz.dll</HintPath>
     </Reference>
     <Reference Include="toofz.NecroDancer, Version=2.0.0.23027, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\toofz.NecroDancer.2.0.0\lib\net45\toofz.NecroDancer.dll</HintPath>

--- a/toofz.NecroDancer.Leaderboards.Tests/HttpRequestStatusHandlerTests.cs
+++ b/toofz.NecroDancer.Leaderboards.Tests/HttpRequestStatusHandlerTests.cs
@@ -40,7 +40,7 @@ namespace toofz.NecroDancer.Leaderboards.Tests
                 var mockHandler = new MockHttpMessageHandler();
                 mockHandler
                     .When("*")
-                    .Respond(HttpStatusCode.BadRequest);
+                    .Respond(HttpStatusCode.BadRequest, "application/json", "");
 
                 var handler = new TestingHttpMessageHandler(new HttpRequestStatusHandler { InnerHandler = mockHandler });
 

--- a/toofz.NecroDancer.Leaderboards/HttpError.cs
+++ b/toofz.NecroDancer.Leaderboards/HttpError.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace toofz.NecroDancer.Leaderboards
+{
+    public sealed class HttpError
+    {
+        public string Message { get; set; }
+        public string ExceptionMessage { get; set; }
+        public string ExceptionType { get; set; }
+        public string StackTrace { get; set; }
+
+        public override string ToString()
+        {
+            var lines = new List<string>();
+
+            if (Message != null)
+                lines.Add($"Message={Message}");
+            if (ExceptionMessage != null)
+                lines.Add($"ExceptionMessage={ExceptionMessage}");
+            if (ExceptionType != null)
+                lines.Add($"ExceptionType={ExceptionType}");
+            if (StackTrace != null)
+                lines.Add($"StackTrace={StackTrace}");
+
+            lines.Insert(0, nameof(HttpError));
+
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        public HttpErrorException ToHttpErrorException()
+        {
+            return new HttpErrorException(Message, StackTrace)
+            {
+                ExceptionMessage = ExceptionMessage,
+                ExceptionType = ExceptionType,
+            };
+        }
+    }
+
+    public sealed class HttpErrorException : Exception
+    {
+        public HttpErrorException(string message, string stackTrace) : base(message)
+        {
+            this.stackTrace = stackTrace;
+        }
+
+        public string ExceptionMessage { get; set; }
+        public string ExceptionType { get; set; }
+
+        readonly string stackTrace;
+        public override string StackTrace => stackTrace;
+    }
+}

--- a/toofz.NecroDancer.Leaderboards/HttpError.cs
+++ b/toofz.NecroDancer.Leaderboards/HttpError.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace toofz.NecroDancer.Leaderboards
 {
@@ -9,24 +8,6 @@ namespace toofz.NecroDancer.Leaderboards
         public string ExceptionMessage { get; set; }
         public string ExceptionType { get; set; }
         public string StackTrace { get; set; }
-
-        public override string ToString()
-        {
-            var lines = new List<string>();
-
-            if (Message != null)
-                lines.Add($"Message={Message}");
-            if (ExceptionMessage != null)
-                lines.Add($"ExceptionMessage={ExceptionMessage}");
-            if (ExceptionType != null)
-                lines.Add($"ExceptionType={ExceptionType}");
-            if (StackTrace != null)
-                lines.Add($"StackTrace={StackTrace}");
-
-            lines.Insert(0, nameof(HttpError));
-
-            return string.Join(Environment.NewLine, lines);
-        }
 
         public HttpErrorException ToHttpErrorException()
         {

--- a/toofz.NecroDancer.Leaderboards/HttpRequestStatusException.cs
+++ b/toofz.NecroDancer.Leaderboards/HttpRequestStatusException.cs
@@ -29,5 +29,7 @@ namespace toofz.NecroDancer.Leaderboards
         /// The status code returned by the server for the request.
         /// </summary>
         public HttpStatusCode StatusCode { get; set; }
+        public Uri RequestUri { get; set; }
+        public string ResponseContent { get; set; }
     }
 }

--- a/toofz.NecroDancer.Leaderboards/HttpRequestStatusHandler.cs
+++ b/toofz.NecroDancer.Leaderboards/HttpRequestStatusHandler.cs
@@ -1,11 +1,16 @@
-﻿using System.Net.Http;
+﻿using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using log4net;
+using Newtonsoft.Json;
 
 namespace toofz.NecroDancer.Leaderboards
 {
     public sealed class HttpRequestStatusHandler : DelegatingHandler
     {
+        static readonly ILog Log = LogManager.GetLogger(typeof(HttpRequestStatusHandler));
+
         /// <summary>
         /// Sends an HTTP request to the inner handler to send to the server as an asynchronous operation.
         /// </summary>
@@ -24,13 +29,34 @@ namespace toofz.NecroDancer.Leaderboards
         {
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            try
+            if (!response.IsSuccessStatusCode)
             {
-                response.EnsureSuccessStatusCode();
-            }
-            catch (HttpRequestException ex)
-            {
-                throw new HttpRequestStatusException(ex.Message, ex) { StatusCode = response.StatusCode };
+                var message = $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}).";
+                var requestUri = request.RequestUri;
+                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                HttpError httpError = null;
+                var serializer = JsonSerializer.CreateDefault();
+                using (var sr = new StringReader(content))
+                {
+                    httpError = (HttpError)serializer.Deserialize(sr, typeof(HttpError));
+                }
+
+                var ex = new HttpRequestStatusException(message)
+                {
+                    StatusCode = response.StatusCode,
+                    RequestUri = requestUri,
+                };
+                if (httpError == null)
+                {
+                    ex.ResponseContent = content;
+                }
+                else
+                {
+                    Log.Error(message, httpError.ToHttpErrorException());
+                }
+
+                throw ex;
             }
 
             return response;

--- a/toofz.NecroDancer.Leaderboards/packages.config
+++ b/toofz.NecroDancer.Leaderboards/packages.config
@@ -53,6 +53,6 @@
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="SteamKit2" version="1.8.3" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
-  <package id="toofz" version="2.1.0" targetFramework="net45" />
+  <package id="toofz" version="2.2.0" targetFramework="net45" />
   <package id="toofz.SqlBulkUpsert" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/toofz.NecroDancer.Leaderboards/toofz.NecroDancer.Leaderboards.csproj
+++ b/toofz.NecroDancer.Leaderboards/toofz.NecroDancer.Leaderboards.csproj
@@ -83,8 +83,8 @@
       <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="toofz, Version=2.1.0.20911, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\toofz.2.1.0\lib\net45\toofz.dll</HintPath>
+    <Reference Include="toofz, Version=2.2.0.19639, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\toofz.2.2.0\lib\net45\toofz.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -124,18 +124,19 @@
     </Compile>
     <Compile Include="Steam\WebApi\SteamWebApiTransientErrorDetectionStrategy.cs" />
     <Compile Include="Steam\WebApi\SteamWebApiTransientFaultHandler.cs" />
-    <Compile Include="DailyEntry.cs" />
-    <Compile Include="DailyLeaderboard.cs" />
-    <Compile Include="Entry.cs" />
-    <Compile Include="HttpContentExtensions.cs" />
-    <Compile Include="HttpRequestStatusException.cs" />
-    <Compile Include="HttpRequestStatusHandler.cs" />
     <Compile Include="toofz\IToofzApiClient.cs" />
     <Compile Include="toofz\Objects.cs" />
     <Compile Include="toofz\Parameters.cs" />
     <Compile Include="toofz\ToofzApiClient.cs">
       <DependentUpon>IToofzApiClient.cs</DependentUpon>
     </Compile>
+    <Compile Include="DailyEntry.cs" />
+    <Compile Include="DailyLeaderboard.cs" />
+    <Compile Include="Entry.cs" />
+    <Compile Include="HttpContentExtensions.cs" />
+    <Compile Include="HttpError.cs" />
+    <Compile Include="HttpRequestStatusException.cs" />
+    <Compile Include="HttpRequestStatusHandler.cs" />
     <Compile Include="ILeaderboardsStoreClient.cs" />
     <Compile Include="LeaderboardsStoreClient.cs">
       <DependentUpon>ILeaderboardsStoreClient.cs</DependentUpon>


### PR DESCRIPTION
* `POST /replays` will report a more specific error when primary key violations occur.

* API clients now log the error response and request URI for a failed request.